### PR TITLE
Na=na   unassigned=unassigned for contracted words

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ utility/packages/
 notes 20240301.txt
 /data/grambank
 /hidden
+/code/output_new_branch

--- a/code/03_process_data_per_UD_proj.R
+++ b/code/03_process_data_per_UD_proj.R
@@ -94,10 +94,8 @@ process_UD_data <- function(input_dir = NULL,
   
   #looping through each of the tsv files, the output from 02_collapse_UD_dirs.R
   
-
-
   for(i in 1:length(fns)){
-    # i <-67
+    # i <-57
     fn <- fns[i]
     
     dir <- basename(fn)  %>% stringr::str_replace_all(".tsv", "")
@@ -108,7 +106,7 @@ process_UD_data <- function(input_dir = NULL,
     
     #reading in
     conllu <- readr::read_tsv(fn, show_col_types = F, col_types =  cols(.default = "c"))
-
+    
     #doing some counting of number of tokens
     n_tokens_in_input <- nrow(conllu)
     n_tokens_empty_dropped <- conllu %>% 
@@ -158,8 +156,10 @@ process_UD_data <- function(input_dir = NULL,
         dplyr::filter(!is.na(token_id)) %>% 
         tidyr::separate(id, into = c("sentence_id", "token_num"), remove = TRUE, , sep = "£", fill = "right") %>% 
         dplyr::group_by(sentence_id, token_id) %>% 
-        dplyr::summarise(feats_contracted = paste0(feats, collapse = "|"), 
-                         upos_contracted = paste0(upos, collapse = "_"), .groups = "drop")
+        dplyr::summarise(feats_contracted = paste0(feats  %>%  na.omit(), collapse = "|"), 
+                         upos_contracted = paste0(upos  %>%  na.omit(), collapse = "_"), .groups = "drop") %>%
+        dplyr::mutate(feats_contracted = ifelse(feats_contracted == "", NA, feats_contracted)) %>%
+        dplyr::mutate(upos_contracted  = ifelse(upos_contracted  == "", NA, upos_contracted )) 
       
       conllu <- conllu  %>% 
         dplyr::anti_join(dplyr::select(df_uncontracted, sentence_id, token_id = token_num), by = c("sentence_id", "token_id")) %>%
@@ -187,7 +187,7 @@ process_UD_data <- function(input_dir = NULL,
     
     ########## SORT OUT TAGGING
     
-    # There are inconsistencies in coding of different UD-projects. It is not the case that every token of the same part-of-speech (upos) are tagged for the same information. For example, some ADJ are tagged for NumType but others aren't. This is most likely not a problem for most UD-purposes, but for this project it causes issues. To address that, we find all the unique feat-types for each upos, and if a token isn't tagged for it, we tag it for it and we denote it as "unassigned". So for example, all ADJ that don't have NumType get "NumType == unassigned". Likewise, tokens that have no morph feats at all, and no token for that UPOS have any, get the morph type "unassigned" with the value "unassigned". This is necessary for the way we later compute surprisal and entropy.
+    # It is not the case that every token of the same part-of-speech (upos) are tagged for the same information, which is not desirable for our project. For example, some ADJ are tagged for NumType but others aren't. This is most likely not a problem for most UD-purposes, but for this project it causes issues. To address that, we find all the unique feat-types for each upos, and if a token isn't tagged for it, we tag it for it and we denote it as "unassigned". So for example, all ADJ that don't have NumType get "NumType == unassigned". Likewise, tokens that have no morph feats at all, and no token for that UPOS have any, get the morph type "unassigned" with the value "unassigned". This is necessary for the way we later compute surprisal and entropy.
   
     #split for morph tags
     conllu_split <- conllu %>%
@@ -283,8 +283,10 @@ calculate_surprisal <- function(input_dir = NULL,
                                 core_features = NULL# core_features_only, all_features
              ){
 
-#input_dir <- "output/processed_data/ud-treebanks-v2.14_processed/agg_level_lemma_all_features/processed_tsv/"
+#input_dir <- "output/processed_data/ud-treebanks-v2.14_processed/agg_level_upos_all_features/processed_tsv/"
 #output_dir <- "output/results/ud-treebanks-v2.14_results"
+#agg_level = ""
+#core_features = "all_features"
   
   if(is.null(output_dir)){
     stop("output_dir is NULL, it needs to be defined.")
@@ -389,7 +391,7 @@ if(!dir.exists(dir_spec)){
 #looping through one tsv at a time
 
 for(i in 1:length(fns)){
-# i <-19
+# i <-57
   fn <- fns[i]
   dir <- basename(fn)  %>% stringr::str_replace_all(".tsv", "")
 
@@ -404,9 +406,11 @@ conllu_split <- conllu %>%
   dplyr::mutate(feats_split = stringr::str_split(feats, "\\|")) %>% #split the feature cell for each feature
   tidyr::unnest(cols = c(feats_split)) %>% #unravel the feature cell into separate rows for each feature
   tidyr::separate(feats_split, sep = "=", into = c("feat_cat", "feat_value"), remove = T, fill = "right")  
-  
-n_feat_cats = conllu_split$feat_cat %>% na.omit() %>% unique()
-n_feat_cats <- n_feat_cats[!grepl("unassigned", n_feat_cats)] %>% length()
+
+feat_cats = conllu_split$feat_cat %>% na.omit() %>% unique()
+feat_cats = feat_cats[!grepl("unassigned", feat_cats)]
+n_feat_cats <- feat_cats %>% length()
+feat_cats <- paste0(unique(conllu_split$feat_cat), collapse = ";")  #for transpercy, also just record all feature categories mentioned
 
 n_feats_per_token_df  <- conllu_split %>%
   dplyr::group_by(id) %>% 
@@ -506,6 +510,7 @@ data.frame(dir = dir,
            TTR = n_types /  n_tokens, 
            LTR = n_lemmas / n_tokens, 
            n_feat_cats = n_feat_cats,
+           feat_cats = feat_cats,
            n_feats_per_token_mean = n_feats_per_token_df$feats_n %>% mean(),
            suprisal_token_mean = surprisal_token$surprisal %>% mean(), 
            sum_surprisal_morph_split_mean = token_surprisal_df$sum_surprisal_morph_split %>% mean() ,
@@ -515,3 +520,4 @@ data.frame(dir = dir,
 
 
 }#end of function
+

--- a/code/04_UD_Genre_plot.R
+++ b/code/04_UD_Genre_plot.R
@@ -79,12 +79,16 @@ meta_list_aligned <- lapply(meta_list, function(df) {
 
 ud_dirs_used <- readr::read_tsv("output/results/all_results.tsv", show_col_types = FALSE) %>% dplyr::pull(dir) 
 
-metadata_df <- do.call(rbind, meta_list_aligned) %>% 
-  dplyr::filter(treebank %in% ud_dirs_used) %>%
-  dplyr::mutate(Genre = stringr::str_split(Genre, " ")) %>% 
-  tidyr::unnest(Genre) 
+metadata_df <- do.call(rbind, meta_list_aligned) 
+
+metadata_df %>% 
+  dplyr::rename(dir = treebank) %>%
+  readr::write_tsv("output/metadata.df")
 
 genre_df <- metadata_df %>% 
+  dplyr::filter(treebank %in% ud_dirs_used) %>%
+  dplyr::mutate(Genre = stringr::str_split(Genre, " ")) %>% 
+  tidyr::unnest(Genre) %>%
   dplyr::group_by(Genre) %>% 
   dplyr::summarise(n = dplyr::n()) %>% 
   dplyr::arrange(dplyr::desc(n))

--- a/code/04_combine_all_data.R
+++ b/code/04_combine_all_data.R
@@ -62,10 +62,11 @@ df <- df %>%
 
 #some datasets don't have the tokens in them
 df <- df %>% 
-  dplyr::mutate(TTR = ifelse(n_types <=2, NA, TTR)) %>% 
+  dplyr::mutate(TTR = ifelse(n_types <=2, NA, TTR)) %>% #if there are fewer than 2 types in the data, set number of types, TTR, LTR and surprisal of token to missing as this indicates that it is not reliable
   dplyr::mutate(LTR = ifelse(n_types <=2, NA, LTR))  %>% 
   dplyr::mutate(suprisal_token_mean = ifelse(n_types <=2, NA, suprisal_token_mean))  %>% 
   dplyr::mutate(n_types = ifelse(n_types <=2, NA, n_types))  %>% 
+  dplyr::mutate(mfh = ifelse(n_total_rows_filtered_mfh == 0, NA, mfh))   %>% #for C&R's mfh measurement, because of the dataset we use as input sometimes the number of tokens the score is based on is in fact 0. In those cases, mfh will also be 0 but it is not a meaningful value because it is based on 0 tokens. We exclude these.
   dplyr::filter(n_feat_cats_all_features >= 2)
 
 df %>% 

--- a/code/04_maps.R
+++ b/code/04_maps.R
@@ -26,7 +26,7 @@ df <- df %>%
 # Sum surprisal morph split mean, agg level = UPOS, all features
 p <- basemap +
   ggplot2::geom_jitter(data = df, mapping = ggplot2::aes(x = Longitude, y = Latitude, fill = sum_surprisal_morph_split_mean_upos_all_features),
-              size = 2, alpha = 0.8, width = 3.5, height=3.5, shape = 21, color = "black") +
+              size = 2, alpha = 0.8, width = 2, height=2, shape = 21, color = "black") +
   ggplot2::ggtitle("morpho-surprisal / feat / UPOS / all features") +
   viridis::scale_fill_viridis(option = "plasma", breaks = c(1,3, 5, 7, 9, 11)) +
   ggplot2::theme( plot.margin = ggplot2::unit(c(0, 0, 0, 0), "cm") , 
@@ -41,7 +41,7 @@ ggplot2::ggsave(filename = "output/plots/map_sum_surprisal_morph_split_mean_upos
 # Surprisal per morph featstring mean, agg level = lemma, core features only
 p <- basemap +
   ggplot2::geom_jitter(data = df, mapping = ggplot2::aes(x = Longitude, y = Latitude, fill = surprisal_per_morph_featstring_mean_lemma_core_features_only), 
-              size = 2, alpha = 0.8, width = 3.5, height=3.5, shape = 21, color = "black") +
+              size = 2, alpha = 0.8, width = 2, height=2, shape = 21, color = "black") +
   ggplot2::ggtitle("morpho-surprisal / featstring  /  lemma / core features only")+
   viridis::scale_fill_viridis(option = "plasma", breaks = c(0, 1,2)) +
   ggplot2::theme( plot.margin = ggplot2::unit(c(0, 0, 0, 0), "cm") , 
@@ -60,7 +60,7 @@ df_PUD  <- df %>%
 # Sum surprisal morph split mean, agg level = UPOS, all features (PUD)
 p <- basemap +
   ggplot2::geom_jitter(data = df_PUD, mapping = ggplot2::aes(x = Longitude, y = Latitude, fill = sum_surprisal_morph_split_mean_upos_all_features),
-              size = 2, alpha = 0.8, width = 3.5, height=3.5, shape = 21, color = "black") +
+              size = 2, alpha = 0.8, width = 2, height=2, shape = 21, color = "black") +
   ggplot2::ggtitle("morpho-surprisal / feat / UPOS / all features (PUD)")+
   viridis::scale_fill_viridis(option = "plasma", breaks = c(0,1,3, 5, 7)) +
   ggplot2::theme( plot.margin = ggplot2::unit(c(0, 0, 0, 0), "cm") , 
@@ -75,7 +75,7 @@ ggplot2::ggsave(filename = "output/plots/map_sum_surprisal_morph_split_mean_upos
 # Surprisal per morph featstring mean, agg level = lemma, core features only (PUD)
 p <- basemap +
   ggplot2::geom_jitter(data = df_PUD, mapping = ggplot2::aes(x = Longitude, y = Latitude, fill = surprisal_per_morph_featstring_mean_lemma_core_features_only), 
-              size = 2, alpha = 0.8, width = 3.5, height=3.5, shape = 21, color = "black") +
+              size = 2, alpha = 0.8, width = 2, height=2, shape = 21, color = "black") +
   ggplot2::ggtitle("morpho-surprisal / featstring  /  lemma / core features only (PUD)")+
   viridis::scale_fill_viridis(option = "plasma", breaks = c(0,0.5, 1,2)) +
   ggplot2::theme( plot.margin = ggplot2::unit(c(0, 0, 0, 0), "cm") , 

--- a/code/04_stack_summaries.R
+++ b/code/04_stack_summaries.R
@@ -34,7 +34,7 @@ custom_metrics_df_4_ways <- all %>%
 
 metrics_df_2_ways <- all %>% 
   dplyr::select(dir, agg_level, core_features,
-"n_feats_per_token_mean", "n_feat_cats" ) %>% 
+"n_feats_per_token_mean", "n_feat_cats" , "feat_cats") %>% 
   reshape2::melt(id.vars = c("dir", "agg_level", "core_features")) %>%
   tidyr::unite(variable, agg_level, core_features, col = "cast_variable", remove = TRUE) %>% 
   reshape2::dcast(dir ~ cast_variable, value.var = "value")


### PR DESCRIPTION
As I was double-checking details for the message to the UD maintainers, I happened to unearth an assumption that proved to be false. When we resolve multiwords (`do` + `n't` -> `don't`) we give the super-word (`don't`) the feat and upos values of the subwords. When there are no features associated with the "sub-words" (`do` + `n't`), the missing value _NA_  was injected as a string `NA` to the super-word - which is not what we want. I have correct this behaviour and re-rendered all the plots and other outputs. The main change is that there are fewer features, because `NA` is no longer a feature. There is a small difference for some of the relevant statistics. The largest difference in terms of correlation is between number of feature categories and our two representative morpho-surprisal statistics for the PUD set (0.59* -> 0.66* and 0.55* -> 0.61*). This does not make a large difference for our overall paper. I am updating the paper. 